### PR TITLE
Changes for use collapse_key, necesary to extend message lifetime

### DIFF
--- a/gcm/management/commands/gcm_messenger.py
+++ b/gcm/management/commands/gcm_messenger.py
@@ -16,7 +16,13 @@ class Command(BaseCommand):
             action='store_true',
             dest='devices',
             default=False,
-            help='List of available devices'),)
+            help='List of available devices'),
+        make_option(
+            '--collapse-key',
+            dest='collapse_key',
+            default='message',
+            help='Set value of collapse_key flag, default is "message"'),
+        )
 
     def handle(self, *args, **options):
 
@@ -28,7 +34,7 @@ class Command(BaseCommand):
                 self.stdout.write("(#%s) %s\n" % (device.id, device.name))
             self.stdout.write("\n")
         else:
-
+            collapse_key = options['collapse_key']
             try:
                 id = args[0]
                 message = args[1]
@@ -41,6 +47,6 @@ class Command(BaseCommand):
             except Device.DoesNotExist:
                 raise CommandError('Unknown device (id=%s). Check list: python manage.py messenger --devices' % id)
             else:
-                result = device.send_message(message)
+                result = device.send_message(message, collapse_key=collapse_key)
 
                 self.stdout.write("[OK] device #%s (%s): %s\n" % (id, device.name, result))

--- a/gcm/models.py
+++ b/gcm/models.py
@@ -29,12 +29,12 @@ class AbstractDevice(models.Model):
         verbose_name_plural = _("Devices")
         ordering = ['-modified_date']
 
-    def send_message(self, msg):
+    def send_message(self, msg, collapse_key="message"):
         return send_gcm_message(
             api_key=settings.GCM_APIKEY,
             regs_id=[self.reg_id],
             data={'msg': msg},
-            collapse_key="message")
+            collapse_key=collapse_key)
 
 
 class Device(AbstractDevice):


### PR DESCRIPTION
Changes for use collapse_key, necesary to extend message lifetime. See http://developer.android.com/google/gcm/adv.html
