### PR TITLE
Add support for needed real life features

### DIFF
--- a/gcm/api.py
+++ b/gcm/api.py
@@ -1,6 +1,16 @@
 import requests
 import json
 
+MAX_RECIPIENTS = 1000
+
+
+def _chunks(items, limit):
+    """
+    Yield successive chunks from list \a items with a minimum size \a limit
+    """
+    for i in range(0, len(items), limit):
+        yield items[i:i + limit]
+
 
 def send_gcm_message(api_key, regs_id, data, collapse_key=None):
     """
@@ -12,6 +22,13 @@ def send_gcm_message(api_key, regs_id, data, collapse_key=None):
     collapse_key: A string to group messages, look at the documentation about it:
         http://developer.android.com/google/gcm/gcm.html#request
     """
+
+    if len(regs_id) > MAX_RECIPIENTS:
+        ret = []
+        for chunk in _chunks(regs_id, MAX_RECIPIENTS):
+            ret.append(send_gcm_message(api_key, chunk, data, collapse_key))
+        return ret
+
     values = {
         'registration_ids': regs_id,
         'collapse_key': collapse_key,

--- a/gcm/models.py
+++ b/gcm/models.py
@@ -47,6 +47,20 @@ class AbstractDevice(models.Model):
             data=data,
             collapse_key=collapse_key)
 
+    def get_queryset(self):
+        return DeviceQuerySet(self.model)
+    get_query_set = get_queryset  # Django < 1.6 compatiblity
+
 
 class Device(AbstractDevice):
     pass
+
+
+class DeviceQuerySet(models.query.QuerySet):
+    def send_message(self, data, collapse_key="message"):
+        if self:
+                return send_gcm_message(
+                    api_key=get_api_key(),
+                    regs_id=list(self.values_list("reg_id", flat=True)),
+                    data=data,
+                    collapse_key=collapse_key)


### PR DESCRIPTION
This pull request adds two things.
1. Support for sending data without limiting to the "msg" field which is not really needed.
2. Support sending bulk messages on a queryset. Sending to an unlimited amount of objects in an efficient way.

These are needed in order to use this framework, as they are both very common real-life use cases.

Note: if you wish, this merge commit can be dropped, and you can just use the 2 commits themselves, as they are not tightly tied.
