### PR TITLE
Handle errors in GCM responses

### DIFF
--- a/gcm/forms.py
+++ b/gcm/forms.py
@@ -22,7 +22,7 @@ class UnregisterDeviceForm(forms.ModelForm):
         fields = ('dev_id',)
 
     def save(self, commit=True):
-        self.instance.is_active = False
+        self.instance.mark_inactive()
         return super(UnregisterDeviceForm, self).save(commit)
 
 


### PR DESCRIPTION
Delete devices from the database if the appropriate errors are returned.
If "error" is different than "Unavailable", delete the device.

This is according to:
http://developer.android.com/google/gcm/http.html
