### PR TITLE
json.loads() expect a str - with python 3.4, response.content is bytes

### DIFF
--- a/gcm/api.py
+++ b/gcm/api.py
@@ -64,4 +64,4 @@ class GCMMessage(object):
             data=values, headers=headers)
 
         response.raise_for_status()
-        return registration_ids, json.loads(response.content)
+        return registration_ids, json.loads(response.content.decode("utf-8"))

--- a/gcm/api.py
+++ b/gcm/api.py
@@ -2,6 +2,7 @@ import requests
 import json
 
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.encoding import force_text
 
 from . import conf
 
@@ -64,4 +65,4 @@ class GCMMessage(object):
             data=values, headers=headers)
 
         response.raise_for_status()
-        return registration_ids, json.loads(response.content.decode("utf-8"))
+        return registration_ids, json.loads(force_text(response.content))


### PR DESCRIPTION
I'm just forcing response.content to be str.

Maybe we could use force_text() from django to achieve this in a proper way?

Could you push the new version including this PR and the following commit: https://github.com/bogdal/django-gcm/commit/fa8a1f0ebf387e6e5eb950584d0ba0251c07b425

Thanks you for your work!

Thomas.