### PR TITLE
fixed gcm messanger

### DIFF
--- a/gcm/management/commands/gcm_messenger.py
+++ b/gcm/management/commands/gcm_messenger.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
                     'python manage.py gcm_messenger --devices' % id)
             else:
                 result = device.send_message(
-                    message, collapse_key=collapse_key)
+                        {'message': message}, collapse_key=collapse_key)
 
                 self.stdout.write("[OK] device #%s (%s): %s\n" %
                                   (id, device.name, result))


### PR DESCRIPTION
the message was always null when send from the gms_messanger, related issiue:
https://github.com/bogdal/django-gcm/issues/39

cahnged to:
result = device.send_message(
                        {'message': message}, collapse_key=collapse_key)


Sorry about previous from pull request! 